### PR TITLE
Require Azure Blob Storage SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,9 @@
     "description": "Azure adapter for Gaufrette",
     "type": "metapackage",
     "require": {
-        "knplabs/gaufrette": "~0.3",
-        "microsoft/windowsazure": "0.*@dev",
-        "microsoft/azure-storage": "~0.15",
+        "knplabs/gaufrette": "~0.5",
+        "microsoft/azure-storage-blob": "^1.0",
         "ext-fileinfo": "*"
-    },
-    "conflict": {
-        "microsoft/windowsazure": "<0.4.3"
     },
     "authors": [
         {


### PR DESCRIPTION
As described in knplabs/Gaufrette#558, the SDK has been split up into 4 separate packages. If the aforementioned PR gets merged, we can raise the minimum version here. Ideally, we would allow both packages but I don't think we can express that.