### PR TITLE
Require Azure Blob Storage SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,9 @@
     "description": "Azure adapter for Gaufrette",
     "type": "metapackage",
     "require": {
-        "knplabs/gaufrette": "~0.3",
-        "microsoft/windowsazure": "0.*@dev",
-        "microsoft/azure-storage": "~0.15",
+        "knplabs/gaufrette": "~0.6",
+        "microsoft/azure-storage-blob": "^1.0",
         "ext-fileinfo": "*"
-    },
-    "conflict": {
-        "microsoft/windowsazure": "<0.4.3"
     },
     "authors": [
         {


### PR DESCRIPTION
Replaces #1 (use gaufrette [`v0.6`](https://github.com/KnpLabs/Gaufrette/releases/tag/v0.6.0)).